### PR TITLE
Update datanway.py

### DIFF
--- a/datanway.py
+++ b/datanway.py
@@ -85,6 +85,6 @@ class OmniglotNShotDataset():
 
             support_cacheX.append(slice_x)
             support_cacheY.append(keras.utils.to_categorical(slice_y,self.classes_per_set))
-            target_cacheY.append(keras.utils.to_categorical(target_y,self.classes_per_set)[0])
+            target_cacheY.append(keras.utils.to_categorical(target_y,self.classes_per_set))
             
         return np.array(support_cacheX), np.array(support_cacheY), np.array(target_cacheY)


### PR DESCRIPTION
fix below ValueError:

match_cosine_1 (MatchCosine)    (None, 5)            0           flatten_1[0][0]
                                                                 flatten_1[1][0]
                                                                 flatten_1[2][0]
                                                                 flatten_1[3][0]
                                                                 flatten_1[4][0]
                                                                 flatten_1[5][0]
                                                                 input_2[0][0]
==================================================================================================
Total params: 112,448
Trainable params: 111,936
Non-trainable params: 512
__________________________________________________________________________________________________
Traceback (most recent call last):
  File "matchingnetwork.py", line 71, in <module>
    epochs=10,batch_size=32,verbose=1)
  File "/usr/local/lib/python3.5/dist-packages/keras/engine/training.py", line 952, in fit
    batch_size=batch_size)
  File "/usr/local/lib/python3.5/dist-packages/keras/engine/training.py", line 789, in _standardize_user_data
    exception_prefix='target')
  File "/usr/local/lib/python3.5/dist-packages/keras/engine/training_utils.py", line 138, in standardize_input_data
    str(data_shape))
ValueError: Error when checking target: expected match_cosine_1 to have shape (5,) but got array with shape (1,)